### PR TITLE
README typo fix

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -39,7 +39,7 @@ You can specify dependencies from different sources (npm, bower or git) and cont
 [source,gradle,subs='attributes']
 ----
 plugins {
-    id 'com.craigburke.client-dependnencies' version '{version}'
+    id 'com.craigburke.client-dependencies' version '{version}'
 }
 
 clientDependencies {


### PR DESCRIPTION
The example DSL code contains a typo in the declaration of the plugin, which might be hard to catch if you're trying out this plugin.
