### PR TITLE
Close Grgit instances and work around file locking issue #46 on Windows.

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/client/registry/npm/NpmResolver.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/npm/NpmResolver.groovy
@@ -65,7 +65,7 @@ class NpmResolver implements Resolver {
             downloadFile.delete()
         } else {
             log.info "Downloading ${dependency} from ${downloadUrl}"
-            Grgit.clone(dir: sourceFolder, uri: downloadUrl, refToCheckout: 'master')
+            Grgit.clone(dir: sourceFolder, uri: downloadUrl, refToCheckout: 'master').close()
         }
     }
 


### PR DESCRIPTION
This fix to #46 has been tested on Windows 7. 

See http://stackoverflow.com/questions/19191727/pack-file-from-git-repo-cant-be-deleted-using-file-delete-method and http://stackoverflow.com/questions/31764311/how-do-i-release-file-system-locks-after-cloning-repo-via-jgit for further info about the JGit issue and the workaround.

Closing the Grgit instances or upgrading to Grgit 1.7 that comes with jgit 4.3.1.201605051710-r did not solve the problem.
