### PR TITLE
Fix #62 No longer throws NPE in `GithubResolver`

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
@@ -85,8 +85,13 @@ class BowerRegistry extends AbstractRegistry implements Registry {
     @Override
     Map loadInfoFromRegistry(Dependency dependency) {
         URL url = new URL("${dependency.registry.url}/packages/${dependency.name}")
-        String jsonText = url.getText(requestProperties: ['User-Agent': DEFAULT_USER_AGENT])
-        new JsonSlurper().parseText(jsonText) as Map
+        try {
+            String jsonText = url.getText(requestProperties: ['User-Agent': DEFAULT_USER_AGENT])
+            return new JsonSlurper().parseText(jsonText) as Map
+        } catch (e) {
+            log.info("Dependency not found in $url ")
+            return null
+        }
     }
 
 }

--- a/src/main/groovy/com/craigburke/gradle/client/registry/core/AbstractRegistry.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/core/AbstractRegistry.groovy
@@ -151,7 +151,7 @@ abstract class AbstractRegistry implements Registry {
                 infoFile.parentFile.mkdirs()
                 infoFile.text = new JsonBuilder(dependency.info).toPrettyString()
             }
-
+            dependency.info = dependency.info ?: [:]
             Resolver resolver = getResolver(dependency)
             resolver.afterInfoLoad(dependency)
         }


### PR DESCRIPTION
No longer throws FileNotFound in `BowerRegistry`
