### PR TITLE
Few null safe fixes for bower

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
@@ -41,11 +41,17 @@ class BowerRegistry extends AbstractRegistry implements Registry {
     @Override
     List<SimpleDependency> getChildDependencies(Dependency dependency) {
         File bowerConfigFile = getConfigFile(dependency.sourceDir)
-        def bowerConfigJson = new JsonSlurper().parse(bowerConfigFile)
 
-        bowerConfigJson.dependencies?.collect { String name, String versionExpression ->
-            new SimpleDependency(name: name, versionExpression: versionExpression)
-        } ?: []
+        if(bowerConfigFile?.exists()) {
+            def bowerConfigJson = new JsonSlurper().parse(bowerConfigFile)
+
+            bowerConfigJson?.dependencies?.collect { String name, String versionExpression ->
+                new SimpleDependency(name: name, versionExpression: versionExpression)
+            } ?: []
+        } else {
+            log.info "No bowerConfigFile for ${dependency}"
+            []
+        }
     }
 
     @Override

--- a/src/main/groovy/com/craigburke/gradle/client/registry/bower/GithubResolver.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/bower/GithubResolver.groovy
@@ -57,7 +57,7 @@ class GithubResolver implements Resolver, GithubCredentials {
         }
 
         GithubInfo info = getInfo(dependency.fullUrl)
-        String ref = dependency.info.tags.find { (it - 'v') == dependency.version.fullVersion } ?: 'master'
+        String ref = dependency.info.tags.find { (it - 'v') == dependency?.version?.fullVersion } ?: 'master'
         URL url = new URL("${GITHUB_BASE_URL}/${info.orgName}/${info.repoName}/tarball/${ref}")
 
         File downloadFile = getDownloadFile(dependency)

--- a/src/main/groovy/com/craigburke/gradle/client/registry/core/AbstractRegistry.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/core/AbstractRegistry.groovy
@@ -204,9 +204,9 @@ abstract class AbstractRegistry implements Registry {
 
     Version getVersionFromSource(File sourceDir) {
         File configFile = getConfigFile(sourceDir)
-        if (configFile) {
+        if (configFile?.exists()) {
             Map config = new JsonSlurper().parse(configFile) as Map
-            Version.parse(config.version as String)
+            config?.version ? Version.parse(config.version as String) : null
         }
         else {
             null


### PR DESCRIPTION
* Allow bower to continue like NPM/YARN if no config file exists for bower
Example repo: https://github.com/flot/flot/

* `fullVersion` null for unmaintained repo, allow it clientDependancies continue
Example repo: https://github.com/vitalets/x-editable
