### PR TITLE
Bower central repository URL has changed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 group = 'com.craigburke.gradle'
-version = '1.4.0'
+version = '1.4.1'
 
 repositories {
     jcenter()

--- a/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/registry/bower/BowerRegistry.groovy
@@ -31,7 +31,7 @@ import groovy.json.JsonSlurper
  */
 class BowerRegistry extends AbstractRegistry implements Registry {
 
-    static final String DEFAULT_BOWER_URL = 'https://bower.herokuapp.com'
+    static final String DEFAULT_BOWER_URL = 'https://registry.bower.io'
     static final List<String> DEFAULT_BOWER_FILENAMES = ['bower.json', '.bower.json']
 
     BowerRegistry(String name, String url = DEFAULT_BOWER_URL, List<String> configFilenames = DEFAULT_BOWER_FILENAMES) {
@@ -97,6 +97,10 @@ class BowerRegistry extends AbstractRegistry implements Registry {
                 requestProperties['User-Agent'] = userAgent
             }
             String jsonText = url.getText(requestProperties: requestProperties)
+            if (!jsonText) {
+                log.warn("Unable to retrieve dependency info from $url")
+                return [:]
+            }
             return new JsonSlurper().parseText(jsonText) as Map
         } catch (e) {
             log.info("Dependency not found in $url ")


### PR DESCRIPTION
url.getText() doesn't follow the 308 permanent redirect and is returning null.  This commit changes the Bower URL and also adds a log warning message if url.getText() returns nothing.
