### PR TITLE
Treat Version tag in exponential notation form as string

### DIFF
--- a/src/main/groovy/com/craigburke/gradle/client/dependency/Version.groovy
+++ b/src/main/groovy/com/craigburke/gradle/client/dependency/Version.groovy
@@ -96,7 +96,7 @@ class Version implements Comparable<Version>, Cloneable {
                     result = 1
                 }
                 else if (part != otherPart) {
-                    if (part.isNumber() && otherPart?.isNumber()) {
+                    if (part.isInteger() && otherPart?.isInteger()) {
                         result = Integer.valueOf(part) <=> Integer.valueOf(otherPart)
                     }
                     else {

--- a/src/test/groovy/com/craigburke/gradle/client/dependency/VersionSpec.groovy
+++ b/src/test/groovy/com/craigburke/gradle/client/dependency/VersionSpec.groovy
@@ -228,6 +228,7 @@ class VersionSpec extends Specification {
         '1.2.3-a.b.c.10.d.5' | '1.2.3-a.b.c.5.d.100'
         '1.2.3-r2'           | '1.2.3-r100'
         '1.2.3-r100'         | '1.2.3-R2'
+        '1.2.3-foo.10e1'     | '1.2.3-foo.100'
     }
 
     @Unroll
@@ -278,6 +279,7 @@ class VersionSpec extends Specification {
         '1.2.3-beta+build' | '1.2.3-beta+otherbuild'
         '1.2.3+build'      | '1.2.3+otherbuild'
         '  v1.2.3+build'   | '1.2.3+otherbuild'
+        '1.2.3-foo.10e1'   | '1.2.3-foo.10e1'
     }
 
 }


### PR DESCRIPTION
Fixes NumberFormatException when comparing versions with tag accidentally in E-notation. For example versions '1.2.3-foo.10e1' and '1.2.3-foo.100' should not be equal and tag '10e1' should be treated as a string.